### PR TITLE
feat(ci): switch docker registry from GitHub to GitLab

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: gchr.io/flags-gg/docs
+          images: registry.gitlab.com/flags-gg/docs
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{raw}}
@@ -92,9 +92,9 @@ jobs:
       - name: Login Github
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: registry.gitlab.com
+          username: ${{ secrets.GITLAB_USERNAME }}
+          password: ${{ secrets.GITLAB_POT }}
       - name: Build and Push
         id: docker_build
         uses: docker/build-push-action@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
           push: true
 
 
-  build_github:
+  build_gitlab:
     runs-on: ubuntu-latest
     environment: production
     steps:


### PR DESCRIPTION
This change updates the Docker login and image metadata actions in the
deployment workflow to use the GitLab container registry instead of the
GitHub container registry. This is done to leverage the GitLab
infrastructure for hosting the Docker images.