### PR TITLE
feat: Update Gitlab registry authentication

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           registry: registry.gitlab.com
           username: ${{ secrets.GITLAB_USERNAME }}
-          password: ${{ secrets.GITLAB_POT }}
+          password: ${{ secrets.GITLAB_PAT }}
       - name: Build and Push
         id: docker_build
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Updates the Gitlab registry authentication to use a Personal
Access Token (PAT) instead of a Password-Only Token (POT). This
provides increased security by using a more secure token type.